### PR TITLE
Rename Key to EncryptionKey to avoid collisions with Flutter Keys

### DIFF
--- a/lib/aes/aes.dart
+++ b/lib/aes/aes.dart
@@ -3,7 +3,7 @@ import 'dart:typed_data';
 
 import 'package:cryptography/cryptography.dart';
 
-import '../keys/key.dart';
+import '../keys/encryption_key.dart';
 import '../encryption/encryption_service.dart';
 import '../encryption/encryption_artefacts.dart';
 import '../encryption/encryption_result.dart';
@@ -23,7 +23,8 @@ class Aes implements EncryptionService {
   /// Provided some binary data and a [SymmetricKey] (key type dependant on the encryption scheme being used)
   /// Return an [EncryptionResult]
   @override
-  Future<EncryptionResult> encryptWithKey(List<int> data, Key key) async {
+  Future<EncryptionResult> encryptWithKey(
+      List<int> data, EncryptionKey key) async {
     assert(key is SymmetricKey, 'AES requires a `SymmetricKey`');
     final artefacts = EncryptionArtefacts(
       authData: utf8.encode('none'),
@@ -36,7 +37,7 @@ class Aes implements EncryptionService {
   /// Pass a string in Cryppo serialized encrypted format and a [SymmetricKey] (key type dependant on the
   /// scheme being used) to return binary decrypted data.
   @override
-  Future<Uint8List> decryptWithKey(String serialized, Key key) {
+  Future<Uint8List> decryptWithKey(String serialized, EncryptionKey key) {
     assert(key is SymmetricKey, 'AES requires a `SymmetricKey`');
     final items = serialized.split('.');
     final decodedPairs = items.sublist(1);
@@ -60,7 +61,7 @@ class Aes implements EncryptionService {
   /// Allows encryption with specified encryption artifacts (rather than generated ones).
   @override
   Future<EncryptionResult> encryptWithKeyAndArtefacts(
-      List<int> data, Key key, EncryptionArtefacts artefacts) async {
+      List<int> data, EncryptionKey key, EncryptionArtefacts artefacts) async {
     final encrypted = await _cipher.encrypt(data,
         secretKey: SecretKey((key as SymmetricKey).bytes),
         nonce: artefacts.nonce,

--- a/lib/encryption/encryption_decryption.dart
+++ b/lib/encryption/encryption_decryption.dart
@@ -3,7 +3,7 @@ import 'dart:typed_data';
 import '../keys/data_encryption_key.dart';
 import '../keys/derivation_strategy.dart';
 import '../keys/derived_key.dart';
-import '../keys/key.dart';
+import '../keys/encryption_key.dart';
 import 'encryption_result.dart';
 import 'encryption_strategy.dart';
 
@@ -13,7 +13,7 @@ typedef DecryptionMethod = Future<Uint8List> Function(
 /// Provided an encrypted+serialized string (in Cryppo's encryption serialization format)
 /// and a [Key] (the type of which depends on the type of encryption used)
 /// return the decrypted binary data.
-Future<List<int>> decryptWithKey({String serialized, Key key}) async {
+Future<List<int>> decryptWithKey({String serialized, EncryptionKey key}) async {
   return _decryptSerialized(serialized, key);
 }
 
@@ -41,12 +41,12 @@ Future<List<int>> decryptWithKeyDerivedFromString(
   return _decryptSerialized(parts.sublist(0, 3).join('.'), derivedKey.key);
 }
 
-/// Encrypts [data] with [key], data must be provided in bytes
-/// A [key] can be a symmetrical key or a key pair, which corresponds to
+/// Encrypts [data] with [EncryptionKey], data must be provided in bytes
+/// A [EncryptionKey] can be a symmetrical key or a key pair, which corresponds to
 /// AES or RSA [EncryptionStrategy]
 Future<EncryptionResult> encryptWithKey({
   EncryptionStrategy encryptionStrategy,
-  Key key,
+  EncryptionKey key,
   List<int> data,
 }) {
   return _encrypt(data: data, encryptionStrategy: encryptionStrategy, key: key);
@@ -54,7 +54,7 @@ Future<EncryptionResult> encryptWithKey({
 
 /// Encrypts [data] with a key derived from [passphrase]
 /// using [keyDerivationStrategy], data must be provided in bytes
-/// A [key] can be a symmetrical key or a key pair, which corresponds to
+/// A [EncryptionKey] can be a symmetrical key or a key pair, which corresponds to
 /// AES or RSA [EncryptionStrategy]
 Future<EncryptionResult> encryptWithDerivedKey({
   EncryptionStrategy encryptionStrategy,
@@ -74,14 +74,15 @@ Future<EncryptionResult> encryptWithDerivedKey({
 /// Convert encryption strategy to a service and encrypt the data
 Future<EncryptionResult> _encrypt({
   EncryptionStrategy encryptionStrategy,
-  Key key,
+  EncryptionKey key,
   Uint8List data,
 }) {
   return encryptionStrategy.toService().encryptWithKey(data, key);
 }
 
 /// Convert encryption strategy to a service and decrypt the data
-Future<List<int>> _decryptSerialized(String serialized, Key key) async {
+Future<List<int>> _decryptSerialized(
+    String serialized, EncryptionKey key) async {
   // Should read from the first part of serialized string
   final items = serialized.split('.');
   final encryptionStrategy = encryptionStrategyFromString(items[0]);

--- a/lib/encryption/encryption_service.dart
+++ b/lib/encryption/encryption_service.dart
@@ -2,21 +2,21 @@ import 'dart:typed_data';
 
 import 'package:cryppo/encryption/encryption_artefacts.dart';
 
-import '../keys/key.dart';
+import '../keys/encryption_key.dart';
 
 import 'encryption_result.dart';
 
 /// Abstract Encryption Service to be implemented by an encryption standard (such as AES-GCM or RSA)
 abstract class EncryptionService {
-  /// Provided some binary data and a [Key] (key type dependant on the encryption scheme being used)
+  /// Provided some binary data and a [EncryptionKey] (key type dependant on the encryption scheme being used)
   /// Return an [EncryptionResult]
-  Future<EncryptionResult> encryptWithKey(List<int> data, Key key);
+  Future<EncryptionResult> encryptWithKey(List<int> data, EncryptionKey key);
 
-  /// Pass a string in Cryppo serialized encrypted format and a [Key] (key type dependant on the
+  /// Pass a string in Cryppo serialized encrypted format and a [EncryptionKey] (key type dependant on the
   /// scheme being used) to return binary decrypted data.
-  Future<Uint8List> decryptWithKey(String serialized, Key key);
+  Future<Uint8List> decryptWithKey(String serialized, EncryptionKey key);
 
   /// Allows encryption with specified encryption artifacts (rather than generated ones).
   Future<EncryptionResult> encryptWithKeyAndArtefacts(
-      List<int> data, Key key, EncryptionArtefacts artefacts);
+      List<int> data, EncryptionKey key, EncryptionArtefacts artefacts);
 }

--- a/lib/keys/data_encryption_key.dart
+++ b/lib/keys/data_encryption_key.dart
@@ -1,5 +1,5 @@
 import 'dart:convert';
-import 'key.dart';
+import 'encryption_key.dart';
 import 'package:cryptography/cryptography.dart';
 import 'package:pointycastle/pointycastle.dart';
 

--- a/lib/keys/derived_key.dart
+++ b/lib/keys/derived_key.dart
@@ -3,7 +3,7 @@ import 'derivation_strategy.dart';
 import 'data_encryption_key.dart';
 import 'derivation_artefacts.dart';
 
-import 'key.dart';
+import 'encryption_key.dart';
 
 /// An encryption key derived from a user-entered string using an algorithm such as Pbkdf2
 class DerivedKey implements SymmetricKey {

--- a/lib/keys/encryption_key.dart
+++ b/lib/keys/encryption_key.dart
@@ -1,0 +1,7 @@
+class EncryptionKey {}
+
+class AsymmetricKey extends EncryptionKey {}
+
+abstract class SymmetricKey extends EncryptionKey {
+  List<int> get bytes;
+}

--- a/lib/rsa/key_pair.dart
+++ b/lib/rsa/key_pair.dart
@@ -1,4 +1,4 @@
-import '../keys/key.dart';
+import '../keys/encryption_key.dart';
 import 'package:ninja/asymmetric/rsa/rsa.dart';
 import 'package:pointycastle/pointycastle.dart' as pointy_castle;
 import 'package:basic_utils/basic_utils.dart';

--- a/lib/rsa/rsa.dart
+++ b/lib/rsa/rsa.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 import 'dart:typed_data';
 
-import '../keys/key.dart';
+import '../keys/encryption_key.dart';
 import '../encryption/encryption_artefacts.dart';
 import '../encryption/encryption_result.dart';
 import '../encryption/encryption_strategy.dart';
@@ -20,14 +20,15 @@ class _Rsa implements EncryptionService {
     return KeyPair.generate(keySize: _keySize);
   }
 
-  Future<EncryptionResult> encryptWithKey(List<int> data, Key key) async {
+  Future<EncryptionResult> encryptWithKey(
+      List<int> data, EncryptionKey key) async {
     assert(key is KeyPair, 'RSA encryption requires a `KeyPair`');
     final KeyPair keyPair = key;
     assert(keyPair.publicKey != null, 'Public key is required for encryption');
     return _encryptWithPublicKey(keyPair.publicKey, data);
   }
 
-  Future<Uint8List> decryptWithKey(String serialized, Key key) async {
+  Future<Uint8List> decryptWithKey(String serialized, EncryptionKey key) async {
     assert(key is KeyPair, 'RSA decryption requires a `KeyPair`');
     final KeyPair keyPair = key;
     assert(
@@ -56,7 +57,7 @@ class _Rsa implements EncryptionService {
 
   @override
   Future<EncryptionResult> encryptWithKeyAndArtefacts(
-      List<int> data, Key key, EncryptionArtefacts artefacts) {
+      List<int> data, EncryptionKey key, EncryptionArtefacts artefacts) {
     // TODO: implement encryptWithKeyAndArtefacts
     throw UnimplementedError();
   }


### PR DESCRIPTION
`Key` is [pretty widely used in Flutter apps](https://api.flutter.dev/flutter/foundation/Key-class.html) to refer to a Widget's `key:`.

Renaming it to `EncryptionKey` should avoid collision headaches.