### PR TITLE
added decrypt encryption result methods

### DIFF
--- a/example/lib/gcm_page.dart
+++ b/example/lib/gcm_page.dart
@@ -193,7 +193,7 @@ class _GcmPageState extends State<GcmPage> {
                         serialisedDerivationArtefactsEditingController.text);
                     final decrypted = await decryptWithKey(
                       key: derivedKey.key,
-                      serialized: serialisedEncryptedDataEditingController.text,
+                      encrypted: serialisedEncryptedDataEditingController.text,
                     );
                     setState(() {
                       plainTextEditingController.text = utf8.decode(decrypted);

--- a/example/lib/rsa_page.dart
+++ b/example/lib/rsa_page.dart
@@ -196,7 +196,7 @@ class _RsaPageState extends State<RsaPage> {
               try {
                 final decryptedText = await decryptWithKey(
                     key: keyPair,
-                    serialized: serialisedCipherTextEditingController.text);
+                    encrypted: serialisedCipherTextEditingController.text);
                 setState(() {
                   plainTextEditingController.text = utf8.decode(decryptedText);
                 });

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -14,21 +14,21 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0-nullsafety"
+    version: "2.5.0-nullsafety.1"
   basic_utils:
     dependency: transitive
     description:
       name: basic_utils
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.6.0"
+    version: "2.7.0-rc.4"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety"
+    version: "2.1.0-nullsafety.1"
   bson:
     dependency: transitive
     description:
@@ -49,28 +49,28 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.2"
+    version: "1.1.0-nullsafety.3"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety"
+    version: "1.2.0-nullsafety.1"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety"
+    version: "1.1.0-nullsafety.1"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0-nullsafety.2"
+    version: "1.15.0-nullsafety.3"
   convert:
     dependency: transitive
     description:
@@ -112,7 +112,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety"
+    version: "1.2.0-nullsafety.1"
   file:
     dependency: transitive
     description:
@@ -197,7 +197,7 @@ packages:
       name: json_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.1"
+    version: "3.1.1"
   logging:
     dependency: transitive
     description:
@@ -211,14 +211,14 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10-nullsafety"
+    version: "0.12.10-nullsafety.1"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.2"
+    version: "1.3.0-nullsafety.3"
   more:
     dependency: transitive
     description:
@@ -267,7 +267,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety"
+    version: "1.8.0-nullsafety.1"
   path_provider:
     dependency: "direct main"
     description:
@@ -323,7 +323,7 @@ packages:
       name: pointycastle
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "2.0.0"
   process:
     dependency: transitive
     description:
@@ -342,56 +342,56 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety"
+    version: "1.8.0-nullsafety.2"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0-nullsafety"
+    version: "1.10.0-nullsafety.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety"
+    version: "2.1.0-nullsafety.1"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety"
+    version: "1.1.0-nullsafety.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety"
+    version: "1.2.0-nullsafety.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19-nullsafety"
+    version: "0.2.19-nullsafety.2"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.2"
+    version: "1.3.0-nullsafety.3"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.2"
+    version: "2.1.0-nullsafety.3"
   video_player:
     dependency: "direct main"
     description:
@@ -421,5 +421,5 @@ packages:
     source: hosted
     version: "0.1.0"
 sdks:
-  dart: ">=2.10.0-0.0.dev <2.10.0"
+  dart: ">=2.10.0-110 <2.11.0"
   flutter: ">=1.12.13+hotfix.5 <2.0.0"

--- a/lib/aes/aes.dart
+++ b/lib/aes/aes.dart
@@ -37,7 +37,8 @@ class Aes implements EncryptionService {
   /// Pass a string in Cryppo serialized encrypted format and a [SymmetricKey] (key type dependant on the
   /// scheme being used) to return binary decrypted data.
   @override
-  Future<Uint8List> decryptWithKey(String serialized, EncryptionKey key) {
+  Future<Uint8List> decryptSerializedStringWithKey(
+      String serialized, EncryptionKey key) {
     assert(key is SymmetricKey, 'AES requires a `SymmetricKey`');
     final items = serialized.split('.');
     final decodedPairs = items.sublist(1);
@@ -75,6 +76,23 @@ class Aes implements EncryptionService {
         strategy: _strategy,
         cipherText: cipherText,
         encryptionArtefacts: artefacts);
+  }
+
+  @override
+  Future<Uint8List> decryptEncryptionResultWithKey(
+      EncryptionResult encryptionResult, EncryptionKey key) {
+    final fullCipher = Uint8List.fromList(encryptionResult.cipherText +
+        encryptionResult.encryptionArtefacts.authTag);
+    return _cipher.decrypt(fullCipher,
+        aad: encryptionResult.encryptionArtefacts.authData,
+        secretKey: SecretKey((key as SymmetricKey).bytes),
+        nonce: Nonce(encryptionResult.encryptionArtefacts.salt));
+  }
+
+  @Deprecated('use decryptSerializedStringWithKey() instead')
+  @override
+  Future<Uint8List> decryptWithKey(String serialized, EncryptionKey key) {
+    return decryptSerializedStringWithKey(serialized, key);
   }
 }
 

--- a/lib/encryption/encryption_decryption.dart
+++ b/lib/encryption/encryption_decryption.dart
@@ -13,8 +13,17 @@ typedef DecryptionMethod = Future<Uint8List> Function(
 /// Provided an encrypted+serialized string (in Cryppo's encryption serialization format)
 /// and a [Key] (the type of which depends on the type of encryption used)
 /// return the decrypted binary data.
-Future<List<int>> decryptWithKey({String serialized, EncryptionKey key}) async {
-  return _decryptSerialized(serialized, key);
+Future<List<int>> decryptWithKey({dynamic encrypted, EncryptionKey key}) async {
+  if (encrypted is String) {
+    return _decryptSerialized(encrypted, key);
+  } else if (encrypted is EncryptionResult) {
+    return encrypted.strategy
+        .toService()
+        .decryptEncryptionResultWithKey(encrypted, key);
+  } else {
+    throw Exception(
+        'encryptedObject is neither a serialised String or an EncryptionResult');
+  }
 }
 
 /// Provided an encrypted+serialized string (in Cryppo's encryption serialization format
@@ -87,5 +96,7 @@ Future<List<int>> _decryptSerialized(
   final items = serialized.split('.');
   final encryptionStrategy = encryptionStrategyFromString(items[0]);
 
-  return await encryptionStrategy.toService().decryptWithKey(serialized, key);
+  return await encryptionStrategy
+      .toService()
+      .decryptSerializedStringWithKey(serialized, key);
 }

--- a/lib/encryption/encryption_service.dart
+++ b/lib/encryption/encryption_service.dart
@@ -14,7 +14,16 @@ abstract class EncryptionService {
 
   /// Pass a string in Cryppo serialized encrypted format and a [EncryptionKey] (key type dependant on the
   /// scheme being used) to return binary decrypted data.
+  @Deprecated('use decryptSerializedStringWithKey() instead')
   Future<Uint8List> decryptWithKey(String serialized, EncryptionKey key);
+
+  Future<Uint8List> decryptSerializedStringWithKey(
+      String serialized, EncryptionKey key);
+
+  /// decrypts a EncryptionResult object obtained from [encryptWithKey()] using [key],
+  /// use this method to avoid unnescessary serialisation/de-serilaisation during decryption
+  Future<Uint8List> decryptEncryptionResultWithKey(
+      EncryptionResult encryptionResult, EncryptionKey key);
 
   /// Allows encryption with specified encryption artifacts (rather than generated ones).
   Future<EncryptionResult> encryptWithKeyAndArtefacts(

--- a/lib/keys/data_encryption_key.dart
+++ b/lib/keys/data_encryption_key.dart
@@ -1,4 +1,6 @@
 import 'dart:convert';
+import 'dart:math';
+import 'dart:typed_data';
 import 'encryption_key.dart';
 import 'package:cryptography/cryptography.dart';
 import 'package:pointycastle/pointycastle.dart';
@@ -23,7 +25,14 @@ class DataEncryptionKey implements SymmetricKey {
 
   /// Create a new random data encryption key
   DataEncryptionKey.generate(int byteLength) {
-    this._key = SecureRandom().nextBytes(byteLength);
+    final secureRandom = SecureRandom('Fortuna'); // Get directly
+    final seedSource = Random.secure();
+    final seeds = <int>[];
+    for (var i = 0; i < 32; i++) {
+      seeds.add(seedSource.nextInt(255));
+    }
+    secureRandom.seed(KeyParameter(Uint8List.fromList(seeds)));
+    this._key = secureRandom.nextBytes(byteLength);
   }
 
   /// Convert raw key bytes into a [DataEncryptionKey]

--- a/lib/rsa/key_pair.dart
+++ b/lib/rsa/key_pair.dart
@@ -18,9 +18,9 @@ class KeyPair implements AsymmetricKey {
      */
     final _privateKey = keyPair.privateKey as pointy_castle.RSAPrivateKey;
     final _publicKey = keyPair.publicKey as pointy_castle.RSAPublicKey;
-    privateKey = RSAPrivateKey(_privateKey.n, _publicKey.e, _privateKey.d,
-        _privateKey.p, _privateKey.q);
-    publicKey = RSAPublicKey(_publicKey.n, _publicKey.e);
+    privateKey = RSAPrivateKey(_privateKey.n, _publicKey.publicExponent,
+        _privateKey.privateExponent, _privateKey.p, _privateKey.q);
+    publicKey = RSAPublicKey(_publicKey.n, _publicKey.publicExponent);
   }
 
   /// Encode the [privateKey] to PKCS8 pem format

--- a/lib/rsa/rsa.dart
+++ b/lib/rsa/rsa.dart
@@ -28,7 +28,8 @@ class _Rsa implements EncryptionService {
     return _encryptWithPublicKey(keyPair.publicKey, data);
   }
 
-  Future<Uint8List> decryptWithKey(String serialized, EncryptionKey key) async {
+  Future<Uint8List> decryptSerializedStringWithKey(
+      String serialized, EncryptionKey key) async {
     assert(key is KeyPair, 'RSA decryption requires a `KeyPair`');
     final KeyPair keyPair = key;
     assert(
@@ -60,6 +61,23 @@ class _Rsa implements EncryptionService {
       List<int> data, EncryptionKey key, EncryptionArtefacts artefacts) {
     // TODO: implement encryptWithKeyAndArtefacts
     throw UnimplementedError();
+  }
+
+  @override
+  Future<Uint8List> decryptEncryptionResultWithKey(
+      EncryptionResult encryptionResult, EncryptionKey key) async {
+    assert(key is KeyPair, 'RSA decryption requires a `KeyPair`');
+    final KeyPair keyPair = key;
+    assert(
+        keyPair.privateKey != null, 'Private key is required for decryption');
+    return _decryptWithPrivateKey(
+        keyPair.privateKey, encryptionResult.cipherText);
+  }
+
+  @Deprecated('use decryptSerializedStringWithKey() instead')
+  @override
+  Future<Uint8List> decryptWithKey(String serialized, EncryptionKey key) {
+    return decryptSerializedStringWithKey(serialized, key);
   }
 }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -14,21 +14,21 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0-nullsafety"
+    version: "2.5.0-nullsafety.1"
   basic_utils:
     dependency: "direct main"
     description:
       name: basic_utils
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.6.0"
+    version: "2.7.0-rc.4"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety"
+    version: "2.1.0-nullsafety.1"
   bson:
     dependency: "direct main"
     description:
@@ -42,28 +42,28 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.2"
+    version: "1.1.0-nullsafety.3"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety"
+    version: "1.2.0-nullsafety.1"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety"
+    version: "1.1.0-nullsafety.1"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0-nullsafety.2"
+    version: "1.15.0-nullsafety.3"
   convert:
     dependency: "direct dev"
     description:
@@ -91,7 +91,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety"
+    version: "1.2.0-nullsafety.1"
   fixnum:
     dependency: transitive
     description:
@@ -123,13 +123,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.1.4"
-  intl:
-    dependency: transitive
-    description:
-      name: intl
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.16.1"
   js:
     dependency: transitive
     description:
@@ -143,7 +136,7 @@ packages:
       name: json_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.1"
+    version: "3.1.1"
   logging:
     dependency: transitive
     description:
@@ -157,14 +150,14 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10-nullsafety"
+    version: "0.12.10-nullsafety.1"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.2"
+    version: "1.3.0-nullsafety.3"
   more:
     dependency: transitive
     description:
@@ -213,7 +206,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety"
+    version: "1.8.0-nullsafety.1"
   pedantic:
     dependency: transitive
     description:
@@ -227,7 +220,7 @@ packages:
       name: pointycastle
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "2.0.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -239,55 +232,55 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety"
+    version: "1.8.0-nullsafety.2"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0-nullsafety"
+    version: "1.10.0-nullsafety.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety"
+    version: "2.1.0-nullsafety.1"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety"
+    version: "1.1.0-nullsafety.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety"
+    version: "1.2.0-nullsafety.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19-nullsafety"
+    version: "0.2.19-nullsafety.2"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.2"
+    version: "1.3.0-nullsafety.3"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.2"
+    version: "2.1.0-nullsafety.3"
 sdks:
-  dart: ">=2.10.0-0.0.dev <2.10.0"
+  dart: ">=2.10.0-110 <2.11.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   cryptography: ^1.4.0
   bson: ^0.3.2
-  pointycastle: ^1.0.2
+  pointycastle: ^2.0.0
   asn1lib: ^0.6.5
   basic_utils: ^2.6.0
   ninja: ^3.0.0

--- a/test/compat_test.dart
+++ b/test/compat_test.dart
@@ -27,7 +27,7 @@ void main() async {
       test('Passes provided key compatibility test $index', () async {
         final key = DataEncryptionKey.loadFromSerialized(testCase['key']);
         final decrypted =
-            await decryptWithKey(key: key, serialized: testCase['serialized']);
+            await decryptWithKey(key: key, encrypted: testCase['serialized']);
         expect(utf8.decode(decrypted), testCase['expected_decryption_result']);
       });
     });
@@ -71,7 +71,7 @@ void main() async {
         final privateKey = KeyPair()
           ..loadPrivateKeyFromPKCS1PemString(testCase['key']);
         final decrypted = await decryptWithKey(
-            serialized: testCase['serialized'], key: privateKey);
+            encrypted: testCase['serialized'], key: privateKey);
         expect(utf8.decode(decrypted), testCase['expected_decryption_result']);
       });
     });

--- a/test/cryppo_test.dart
+++ b/test/cryppo_test.dart
@@ -28,16 +28,28 @@ void main() {
         '5b4365749b5df9db9c1cbe28d3630168561859023d181e1774ae418a400cc50b');
   });
 
-  test('decrypts', () async {
+  test('decrypts serialised strings', () async {
     final derviedKey =
         await deriveKeyWithSerializedOptions('Souvlaki Jay Kunde', serialized);
 
     final decrypted = await decryptWithKey(
         key: derviedKey.key,
-        serialized:
+        encrypted:
             'Aes256Gcm.lOQl2ZU=.QUAAAAAFaXYADAAAAAAXch1m7nNZrl6peqIFYXQAEAAAAACvFVliOK4jwSAZH0JkcO8yAmFkAAUAAABub25lAAA=');
 
     expect(utf8.decode(decrypted), 'Hello');
+  });
+
+  test('decrypts EncryptionResult objects', () async {
+    final key = DataEncryptionKey.generate(32);
+    final data = utf8.encode('This is a test');
+
+    final encrypted = await encryptWithKey(
+        data: data, encryptionStrategy: EncryptionStrategy.aes256Gcm, key: key);
+
+    final decrypted = await decryptWithKey(key: key, encrypted: encrypted);
+
+    expect(utf8.decode(decrypted), 'This is a test');
   });
 
   test('encrypts', () async {
@@ -53,7 +65,7 @@ void main() {
         key: derivedKey.key);
 
     final decrypted = await decryptWithKey(
-        key: derivedKey.key, serialized: encrypted.serialize());
+        key: derivedKey.key, encrypted: encrypted.serialize());
 
     expect(encrypted.serialize().startsWith('Aes256Gcm.'), true);
     expect(utf8.decode(decrypted), plainText);

--- a/test/file_encryption_test.dart
+++ b/test/file_encryption_test.dart
@@ -71,7 +71,7 @@ main() async {
     () async {
       // decrypt and combine each chunk into a single file
       List<int> decryptedFileData = (await Future.wait(serialisedEncryptedChunks
-              .map((e) => decryptWithKey(serialized: e, key: key))))
+              .map((e) => decryptWithKey(encrypted: e, key: key))))
           .reduce((v, e) => v + e);
       final fileData = fileDescriptor.readAsBytesSync();
       expect(decryptedFileData, fileData,

--- a/test/rsa_test.dart
+++ b/test/rsa_test.dart
@@ -18,7 +18,7 @@ Future<void> main() async {
         encryptionStrategy: EncryptionStrategy.rsa4096);
     expect(encryptionResult.serialize().startsWith('Rsa4096.'), true);
     final decryptedBytes =
-        await rsa.decryptWithKey(encryptionResult.serialize(), keyPair);
+        await rsa.decryptEncryptionResultWithKey(encryptionResult, keyPair);
     final decryptedString = utf8.decode(decryptedBytes);
     expect(longString, decryptedString,
         reason: "string must match after encryption and decryption");


### PR DESCRIPTION
Added methods to decrypt `EncryptionResult` directly instead of having to serialise it and deserialise it to decrypt
Fixed a bug related to generating a `DataEncryptionKey`, which calls `SecureRandom()` without supplying any algorithms
Changed API of `decryptWithKey()` to incorporate both decrypting serialise strings and `EncryptionResult` objects