### PR TITLE
added derivation artefact tests

### DIFF
--- a/test/keys/derivation_artefacts_test.dart
+++ b/test/keys/derivation_artefacts_test.dart
@@ -1,0 +1,15 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../lib/keys/derivation_artefacts.dart';
+import '../../lib/keys/derivation_strategy.dart';
+
+void main() {
+  test('generate a derivation artefact with correct default properties', () {
+    final derivationArtefact = DerivationArtefacts.generate();
+    expect(derivationArtefact.length, 32);
+    expect(derivationArtefact.strategy, DerivationStrategy.pbkdf2Hmac);
+    expect(derivationArtefact.salt.length, 20);
+    expect(derivationArtefact.version, 'K');
+    expect(derivationArtefact.iterations, greaterThanOrEqualTo(20000));
+  });
+}

--- a/test/pbkdf2_hmac/pbkdf2_hmac_test.dart
+++ b/test/pbkdf2_hmac/pbkdf2_hmac_test.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../lib/keys/derivation_artefacts.dart';
+import '../../lib/keys/derivation_strategy.dart';
+import '../../lib/pbkdf2_hmac/pbkdf2_hmac.dart';
+
+void main() {
+  test('derive key with correct length', () async {
+    final passphrase = 'test';
+    final data1 = await Pbkdf2Hmac().deriveKey(
+        artefacts: DerivationArtefacts.generate(
+            strategy: DerivationStrategy.pbkdf2Hmac),
+        passphrase: passphrase);
+    expect(data1.length, 32);
+
+    final data2 = await Pbkdf2Hmac().deriveKey(
+        artefacts: DerivationArtefacts.generate(
+            defaultLength: 48, strategy: DerivationStrategy.pbkdf2Hmac),
+        passphrase: passphrase);
+    expect(data2.length, 48);
+  });
+}


### PR DESCRIPTION
As requested, these tests are mainly to prevent defaultLength not being taken into account when generating DerivationArtefacts